### PR TITLE
Fix regexp to also match float numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export type RelativeUnit = keyof typeof Relative;
 
 export type Unit = AbsoluteUnit | RelativeUnit;
 
-export const UnitRegexpStr = `(?:\\s|^)(\\d+)(${Object.keys(Units).join('|')})(?:\\s|$|\\n)`;
+export const UnitRegexpStr = `(?:\\s|^)(\\d*(?:\\.\\d+)?)(${Object.keys(Units).join('|')})(?:\\s|$|\\n)`;
 export const UnitRegexp = new RegExp(UnitRegexpStr);
 export const UnitRegexpGM = new RegExp(UnitRegexpStr, 'gm');
 


### PR DESCRIPTION
Matches floats, e.g. '3.5vw' and '.25rem'.